### PR TITLE
Fix deprecated APIs for Home Assistant 2025.6+

### DIFF
--- a/custom_components/bedjet/__init__.py
+++ b/custom_components/bedjet/__init__.py
@@ -4,11 +4,9 @@ async def async_setup(hass, config):
     return True
 
 async def async_setup_entry(hass, entry):
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "climate")
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, ["climate"])
     return True
 
 async def async_unload_entry(hass, entry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_forward_entry_unload(entry, "climate")
+    return await hass.config_entries.async_unload_platforms(entry, ["climate"])


### PR DESCRIPTION
## Summary

Updates deprecated Home Assistant APIs to fix compatibility with HA 2025.6+.

## Changes

- Replace `async_forward_entry_setup` with `async_forward_entry_setups`
- Replace `async_forward_entry_unload` with `async_unload_platforms`
- Remove unnecessary `async_create_task` wrapper

## Motivation

These APIs were deprecated in Home Assistant 2025.6 and subsequently removed. Without this fix, the integration fails immediately with "Failed to set up: Check the logs" error when adding to HA 2025.6 or later.

## Testing

Tested on Home Assistant 2025.10.4 - integration now loads successfully and discovers BedJet devices via Bluetooth.

Fixes #11